### PR TITLE
RED-196948: Update process exporter to Go 1.26.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.3'
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.25.8'
+          go-version: '1.26.3'
 
       - run: make test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Start from a Debian image with the latest version of Go installed
 # and a workspace (GOPATH) configured at /go.
-FROM --platform=$BUILDPLATFORM golang:1.25.8 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS build
 ARG TARGETARCH
 ARG BUILDPLATFORM
 WORKDIR /go/src/github.com/ncabatoff/process-exporter

--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ docker:
 	docker run --rm --volumes-from configs "$(DOCKER_IMAGE_NAME):$(TAG_VERSION)" $(SMOKE_TEST)
 
 dockertest:
-	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.25.8  make -C /go/src/github.com/ncabatoff/process-exporter test
+	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.26.3  make -C /go/src/github.com/ncabatoff/process-exporter test
 
 dockerinteg:
-	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.25.8  make -C /go/src/github.com/ncabatoff/process-exporter build integ
+	docker run --rm -it -v `pwd`:/go/src/github.com/ncabatoff/process-exporter golang:1.26.3  make -C /go/src/github.com/ncabatoff/process-exporter build integ
 
 .PHONY: update-go-deps
 update-go-deps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ncabatoff/process-exporter
 
-go 1.25.8
+go 1.26.3
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Toolchain-only version bumps with no runtime or security logic changes in the diff.
> 
> **Overview**
> Bumps the **process-exporter** build toolchain from **Go 1.25.8** to **Go 1.26.3** everywhere the version is pinned.
> 
> **`go.mod`** declares `go 1.26.3`. GitHub Actions **build** and **release** workflows use that version via `setup-go`. The **Dockerfile** build stage uses `golang:1.26.3`, and **Makefile** `dockertest` / `dockerinteg` run inside the same image tag. No application source or exporter logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db66017225e06ef0efe216a62fa20ef7e076d6f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->